### PR TITLE
[CHORE] 배포 스크립트 업데이트 + cert 추가하기

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,9 @@ WORKDIR /build
 COPY . .
 RUN buf generate idl/proto
 
+FROM alpine:latest as certs
+RUN apk --update add ca-certificates
+
 FROM golang:1.21-alpine AS builder
 
 ENV GO111MODULE=on \
@@ -18,5 +21,6 @@ RUN go build -o main .
 
 FROM scratch
 WORKDIR /app
+COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=builder /build/main /build/.env /app/
 ENTRYPOINT ["./main"]

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -4,8 +4,8 @@
 git pull origin main
 git submodule update --recursive
 
-# Remove unused docker images
-docker image prune -af
+# Remove unused docker images & build cache
+docker system prune
 
 # Build and run the docker containers
 docker compose build


### PR DESCRIPTION
## Proposed Changes

- docker 빌드 캐시로 gcp 디스크가 꽉 차서 배포가 안되는 문제 발생
- docker system prune 명령어를 추가해서 이전 캐시나 안쓰는 이미지 삭제하도록 함
- firebase admin skd 사용 도중 tls 에러가 발생해서 도커파일에 인증서 추가
